### PR TITLE
Fix loading of mz files

### DIFF
--- a/js/services.js
+++ b/js/services.js
@@ -604,12 +604,13 @@ angular.module('servicesZ', ['dialogs.main'])
                     headers[w] = headers[w].trim();
                 }
                 var fakes = [];
+                var notFloatColumns = ['Name', 'Type', 'AutoTID', 'FinTID'];
                 for (var i = 0; i < lines.length - 1; i++) {
                     if (lines[i].indexOf("#") == 0) continue;
                     var columns = lines[i].split(',');
                     var res = {filename: filename, v: version};
                     for (var j = 0; j < columns.length; j++) {
-                        if ((headers[j] != 'Name') && (headers[j] != 'Type') && (isFloatString(columns[j]))) {
+                        if ((notFloatColumns.indexOf(headers[j]) == -1) && (isFloatString(columns[j]))) {
                             res[headers[j]] = parseFloat(columns[j].trim());
                         } else {
                             res[headers[j]] = columns[j].trim();

--- a/js/services.js
+++ b/js/services.js
@@ -609,7 +609,7 @@ angular.module('servicesZ', ['dialogs.main'])
                     var columns = lines[i].split(',');
                     var res = {filename: filename, v: version};
                     for (var j = 0; j < columns.length; j++) {
-                        if (isFloatString(columns[j])) {
+                        if ((headers[j] != 'Name') && (headers[j] != 'Type') && (isFloatString(columns[j]))) {
                             res[headers[j]] = parseFloat(columns[j].trim());
                         } else {
                             res[headers[j]] = columns[j].trim();


### PR DESCRIPTION
When loading .mz files, there are a few columns that should not be converted to float:
- Name: I have names like "00001" which were converted to float, and then a new key was created in the local storage and the imported results were not associated with my FITS file.
- AutoTID and FinTID: this is more tricky, loading the file was ok, but then downloading broke because the fields were float.
